### PR TITLE
Refactor: Tests: Add a custom render for all tests, wrapped with Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ If you don't want to use `nvm`, make sure that `node -v` returns a version great
 
 * `- app` :The app component and global state management files are located in the root `app/` folder since they are logicallly related.
 * Each component has a dedicated folder for the TSX, CSS and tests for it. I feel this allows easier referencing within files and also makes the components very easy to add/remove, doing so together for all the parts.
+
+> Opinion: I like to keep my types inside of the components for two reasons. 
+> 1. Global types should really be global and should be easy for anyone to grasp what those types are from reading the file. Adding all types to global would make it bloated.
+> 1. Having them in the components makes it easy to infer from the import signature about the nature of the types.
+> One option to explore is to have the types of each component in a related file to make it possible to replace implementations altogether and make adjustments based on the types.
     ```
     - components
         -- Component

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { Provider } from 'react-redux';
+import { render, screen } from 'test-utils/testUtils';
 
 import App from 'app/App';
-import { store } from 'app/store';
 
+/**
+ * @function setupApp
+ * @private
+ *
+ * Reusable helper function to render the component and optionally
+ * perform functions common to the tests using it
+ */
 function setupApp() {
-    render(
-        <Provider store={store}>
-            <App />
-        </Provider>
-    );
+    render(<App />);
 }
 describe('<App />', () => {
     it('renders app', () => {

--- a/src/components/Currency/__tests__/CurrencyItem.test.tsx
+++ b/src/components/Currency/__tests__/CurrencyItem.test.tsx
@@ -10,6 +10,8 @@ import { Currency } from 'types/currency';
  * @function renderCompleteCurrencyItem
  * @memberof CurrencyItem.test
  *
+ * Reusable helper function to render the component and optionally
+ * perform functions common to the tests using it.
  * Renders the CurrencyItem component using a sample currency item.
  * @param {string} currency Currency symbol
  *

--- a/src/components/Currency/__tests__/CurrencyList.EmptyResults.test.tsx
+++ b/src/components/Currency/__tests__/CurrencyList.EmptyResults.test.tsx
@@ -1,20 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { Provider } from 'react-redux';
+import { render, screen, waitFor } from 'test-utils/testUtils';
 
 import { server } from 'mocks/mockServer';
 import { currencyHandlerEmpty } from 'mocks/handlers';
 
-import { store } from 'app/store';
 import CurrencyList from 'components/Currency/CurrencyList';
 
 describe('<CurrencyList/> with empty data', () => {
     it('should show an appropriate message if API returns 0 currencies', async () => {
         server.use(currencyHandlerEmpty);
-        render(
-            <Provider store={store}>
-                <CurrencyList />
-            </Provider>
-        );
+        render(<CurrencyList />);
         await waitFor(() => {
             expect(screen.queryByText('Loading Currencies...')).not.toBeInTheDocument();
         });

--- a/src/components/Currency/__tests__/CurrencyList.ErrorResponse.test.tsx
+++ b/src/components/Currency/__tests__/CurrencyList.ErrorResponse.test.tsx
@@ -1,20 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { Provider } from 'react-redux';
+import { render, screen, waitFor } from 'test-utils/testUtils';
 
 import { server } from 'mocks/mockServer';
 import { currencyHandlerException } from 'mocks/handlers';
 
-import { store } from 'app/store';
 import CurrencyList from 'components/Currency/CurrencyList';
 
 describe('<CurrencyList/> with error in API', () => {
     it('should show an error message if API call failed', async () => {
         server.use(currencyHandlerException);
-        render(
-            <Provider store={store}>
-                <CurrencyList />
-            </Provider>
-        );
+        render(<CurrencyList />);
         await waitFor(() => {
             expect(screen.queryByText('Loading Currencies...')).not.toBeInTheDocument();
         });

--- a/src/components/Currency/__tests__/CurrencyList.test.tsx
+++ b/src/components/Currency/__tests__/CurrencyList.test.tsx
@@ -1,20 +1,25 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { Provider } from 'react-redux';
+import { render, screen, waitFor } from 'test-utils/testUtils';
 
 import fxData from 'mocks/data/fx.json';
 
-import { store } from 'app/store';
 import CurrencyList from 'components/Currency/CurrencyList';
 
+/**
+ * @function renderCurrencyList
+ * @memberof CurrencyList.test
+ *
+ * Reusable helper function to render the component and optionally
+ * perform functions common to the tests using it.
+ * Renders the CurrencyList component and returns a promise to wait for
+ * currencies to be loaded.
+ * @param {string} currency Currency symbol
+ *
+ * @returns {Object} returns `utils` returned from render, `baseCurrency` and `currencyData` used
+ */
 const renderCurrencyList = async () => {
-    const utils = render(
-        <Provider store={store}>
-            <CurrencyList />
-        </Provider>
-    );
-    // Show loading currencies while fetching from API
+    const utils = render(<CurrencyList />);
     await waitFor(() => {
-        // and then hide it when SUCCESS/api failure
+        // hide message when SUCCESS/api failure
         expect(screen.queryByText('Loading Currencies...')).not.toBeInTheDocument();
     });
     return utils;

--- a/src/test-utils/testUtils.tsx
+++ b/src/test-utils/testUtils.tsx
@@ -1,0 +1,15 @@
+import React, { FC, ReactElement } from 'react';
+import { render as testingLibraryRender, RenderOptions } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import { store } from 'app/store';
+
+const Providers: FC = ({ children }) => {
+    return <Provider store={store}>{children}</Provider>;
+};
+const render = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+    testingLibraryRender(ui, { wrapper: Providers, ...options });
+// re-export everything
+export * from '@testing-library/react';
+// override render method
+export { render };


### PR DESCRIPTION
Fix #8 to use a centralized render. Future tests can simply import this and use.
```
import { render, screen, <anything else from '@testing-library/react'> } from 'test-utils/testUtils';
```