### PR TITLE
Reduce responsibilities of currencies slice

### DIFF
--- a/src/components/Currency/redux/currenciesDataSlice.ts
+++ b/src/components/Currency/redux/currenciesDataSlice.ts
@@ -2,9 +2,13 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { currenciesDataInitialState } from 'types/currency';
 import { apiState } from 'types/global';
+import {
+    onFetchCurrenciesPending,
+    updateFilteredCurrenciesReducer
+} from 'components/Currency/redux/currenciesReducers';
+
 import utils from 'utils/currency';
 import { currencyService } from 'http/apiServices';
-import { updateFilteredCurrenciesReducer } from './currenciesReducers';
 
 const SLICE_NAME = 'currenciesData';
 const FETCH_CURRENCIES_THUNK_NAME = `${SLICE_NAME}/fetchCurrencies`;
@@ -20,9 +24,7 @@ export const currenciesDataSlice = createSlice({
     },
     extraReducers(builder) {
         builder
-            .addCase(fetchCurrencies.pending, (state, action) => {
-                state.status.state = apiState.LOADING;
-            })
+            .addCase(fetchCurrencies.pending, onFetchCurrenciesPending)
             .addCase(fetchCurrencies.fulfilled, (state, action) => {
                 state.status.state = apiState.SUCCESS;
                 // Stringify data and then set state variables

--- a/src/components/Currency/redux/currenciesDataSlice.ts
+++ b/src/components/Currency/redux/currenciesDataSlice.ts
@@ -1,31 +1,12 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { Currency } from 'types/currency';
-import { apiStatus, apiState } from 'types/global';
+import { currenciesDataInitialState, currenciesDataState } from 'types/currency';
+import { apiState } from 'types/global';
 import utils from 'utils/currency';
 import { currencyService } from 'http/apiServices';
 
 const SLICE_NAME = 'currenciesData';
 const FETCH_CURRENCIES_THUNK_NAME = `${SLICE_NAME}/fetchCurrencies`;
-
-// Describes the shape of the currencies data slice
-interface currenciesDataState {
-    currencies: Currency[];
-    filteredCurrencies: Currency[];
-    baseCurrency: string;
-    status: apiStatus;
-}
-
-//Provide initial state
-export const currenciesDataInitialState: currenciesDataState = {
-    currencies: [],
-    filteredCurrencies: [],
-    baseCurrency: '',
-    status: {
-        state: apiState.PRISTINE,
-        error: null
-    }
-};
 
 export const fetchCurrencies = createAsyncThunk(FETCH_CURRENCIES_THUNK_NAME, currencyService.getCurrenciesData);
 // Create the currencies data slice

--- a/src/components/Currency/redux/currenciesDataSlice.ts
+++ b/src/components/Currency/redux/currenciesDataSlice.ts
@@ -1,13 +1,13 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { currenciesDataInitialState } from 'types/currency';
-import { apiState } from 'types/global';
 import {
+    onFetchCurrenciesFailure,
     onFetchCurrenciesPending,
+    onFetchCurrenciesSuccess,
     updateFilteredCurrenciesReducer
 } from 'components/Currency/redux/currenciesReducers';
 
-import utils from 'utils/currency';
 import { currencyService } from 'http/apiServices';
 
 const SLICE_NAME = 'currenciesData';
@@ -25,14 +25,7 @@ export const currenciesDataSlice = createSlice({
     extraReducers(builder) {
         builder
             .addCase(fetchCurrencies.pending, onFetchCurrenciesPending)
-            .addCase(fetchCurrencies.fulfilled, (state, action) => {
-                state.status.state = apiState.SUCCESS;
-                // Stringify data and then set state variables
-                const { baseCurrency, fx } = utils.transformJSONToAllStrings(action.payload);
-                state.baseCurrency = baseCurrency;
-                state.currencies = fx;
-                state.filteredCurrencies = fx;
-            })
+            .addCase(fetchCurrencies.fulfilled, onFetchCurrenciesSuccess)
             .addCase(fetchCurrencies.rejected, onFetchCurrenciesFailure);
     }
 });

--- a/src/components/Currency/redux/currenciesDataSlice.ts
+++ b/src/components/Currency/redux/currenciesDataSlice.ts
@@ -33,10 +33,7 @@ export const currenciesDataSlice = createSlice({
                 state.currencies = fx;
                 state.filteredCurrencies = fx;
             })
-            .addCase(fetchCurrencies.rejected, (state, action) => {
-                state.status.state = apiState.FAILURE;
-                state.status.error = action.error.message || 'Unkown Server Error';
-            });
+            .addCase(fetchCurrencies.rejected, onFetchCurrenciesFailure);
     }
 });
 

--- a/src/components/Currency/redux/currenciesDataSlice.ts
+++ b/src/components/Currency/redux/currenciesDataSlice.ts
@@ -1,28 +1,22 @@
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
-import { currenciesDataInitialState, currenciesDataState } from 'types/currency';
+import { currenciesDataInitialState } from 'types/currency';
 import { apiState } from 'types/global';
 import utils from 'utils/currency';
 import { currencyService } from 'http/apiServices';
+import { updateFilteredCurrenciesReducer } from './currenciesReducers';
 
 const SLICE_NAME = 'currenciesData';
 const FETCH_CURRENCIES_THUNK_NAME = `${SLICE_NAME}/fetchCurrencies`;
 
 export const fetchCurrencies = createAsyncThunk(FETCH_CURRENCIES_THUNK_NAME, currencyService.getCurrenciesData);
+
 // Create the currencies data slice
 export const currenciesDataSlice = createSlice({
     name: 'currenciesData',
     initialState: currenciesDataInitialState,
     reducers: {
-        updateFilteredCurrencies(state: currenciesDataState, action: PayloadAction<string>) {
-            if (action.payload) {
-                state.filteredCurrencies = state.currencies.filter((currency) =>
-                    utils.isSearchTermPresentInCurrency(currency, action.payload)
-                );
-            } else {
-                state.filteredCurrencies = state.currencies;
-            }
-        }
+        updateFilteredCurrencies: updateFilteredCurrenciesReducer
     },
     extraReducers(builder) {
         builder

--- a/src/components/Currency/redux/currenciesReducers.ts
+++ b/src/components/Currency/redux/currenciesReducers.ts
@@ -1,0 +1,14 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import { currenciesDataState } from 'types/currency';
+import utils from 'utils/currency';
+
+export const updateFilteredCurrenciesReducer = (state: currenciesDataState, action: PayloadAction<string>) => {
+    if (action.payload) {
+        state.filteredCurrencies = state.currencies.filter((currency) =>
+            utils.isSearchTermPresentInCurrency(currency, action.payload)
+        );
+    } else {
+        state.filteredCurrencies = state.currencies;
+    }
+};

--- a/src/components/Currency/redux/currenciesReducers.ts
+++ b/src/components/Currency/redux/currenciesReducers.ts
@@ -48,8 +48,17 @@ export const updateFilteredCurrenciesReducer = (state: currenciesDataState, acti
     }
 };
 
-export const onFetchCurrenciesPending = function (state: WritableDraft<currenciesDataState>) {
+export const onFetchCurrenciesPending = (state: WritableDraft<currenciesDataState>) => {
     state.status.state = apiState.LOADING;
+};
+
+export const onFetchCurrenciesSuccess = (state: WritableDraft<currenciesDataState>, action: actionTypeSuccess) => {
+    state.status.state = apiState.SUCCESS;
+    // Stringify data and then set state variables
+    const { baseCurrency, fx } = utils.transformJSONToAllStrings(action.payload);
+    state.baseCurrency = baseCurrency;
+    state.currencies = fx;
+    state.filteredCurrencies = fx;
 };
 export const onFetchCurrenciesFailure = (state: WritableDraft<currenciesDataState>, action: actionTypeFailure) => {
     state.status.state = apiState.FAILURE;

--- a/src/components/Currency/redux/currenciesReducers.ts
+++ b/src/components/Currency/redux/currenciesReducers.ts
@@ -1,6 +1,9 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
 import { currenciesDataState } from 'types/currency';
+import { WritableDraft } from 'immer/dist/internal';
+import { apiState } from 'types/global';
+
 import utils from 'utils/currency';
 
 export const updateFilteredCurrenciesReducer = (state: currenciesDataState, action: PayloadAction<string>) => {
@@ -11,4 +14,8 @@ export const updateFilteredCurrenciesReducer = (state: currenciesDataState, acti
     } else {
         state.filteredCurrencies = state.currencies;
     }
+};
+
+export const onFetchCurrenciesPending = function (state: WritableDraft<currenciesDataState>) {
+    state.status.state = apiState.LOADING;
 };

--- a/src/components/Currency/redux/currenciesReducers.ts
+++ b/src/components/Currency/redux/currenciesReducers.ts
@@ -1,10 +1,30 @@
-import { PayloadAction } from '@reduxjs/toolkit';
+import { WritableDraft } from 'immer/dist/internal';
+import { PayloadAction } from '@reduxjs/toolkit/dist/createAction';
+import { SerializedError } from '@reduxjs/toolkit/dist/createAsyncThunk';
 
 import { currenciesDataState } from 'types/currency';
-import { WritableDraft } from 'immer/dist/internal';
 import { apiState } from 'types/global';
-
 import utils from 'utils/currency';
+
+type actionTypeFailure = PayloadAction<
+    unknown,
+    string,
+    {
+        arg: void;
+        requestId: string;
+        requestStatus: 'rejected';
+        aborted: boolean;
+        condition: boolean;
+    } & (
+        | {
+              rejectedWithValue: true;
+          }
+        | {
+              rejectedWithValue: false;
+          }
+    ),
+    SerializedError
+>;
 
 export const updateFilteredCurrenciesReducer = (state: currenciesDataState, action: PayloadAction<string>) => {
     if (action.payload) {
@@ -18,4 +38,8 @@ export const updateFilteredCurrenciesReducer = (state: currenciesDataState, acti
 
 export const onFetchCurrenciesPending = function (state: WritableDraft<currenciesDataState>) {
     state.status.state = apiState.LOADING;
+};
+export const onFetchCurrenciesFailure = (state: WritableDraft<currenciesDataState>, action: actionTypeFailure) => {
+    state.status.state = apiState.FAILURE;
+    state.status.error = action.error.message || 'Unkown Server Error';
 };

--- a/src/components/Currency/redux/currenciesReducers.ts
+++ b/src/components/Currency/redux/currenciesReducers.ts
@@ -3,8 +3,20 @@ import { PayloadAction } from '@reduxjs/toolkit/dist/createAction';
 import { SerializedError } from '@reduxjs/toolkit/dist/createAsyncThunk';
 
 import { currenciesDataState } from 'types/currency';
+import { currenciesResponseData } from 'http/clients/CurrencyApi';
 import { apiState } from 'types/global';
 import utils from 'utils/currency';
+
+type actionTypeSuccess = PayloadAction<
+    currenciesResponseData,
+    string,
+    {
+        arg: void;
+        requestId: string;
+        requestStatus: 'fulfilled';
+    },
+    never
+>;
 
 type actionTypeFailure = PayloadAction<
     unknown,

--- a/src/types/currency.ts
+++ b/src/types/currency.ts
@@ -1,3 +1,5 @@
+import { apiState, apiStatus } from 'types/global';
+
 export type Currency = {
     currency: string;
     nameI18N?: string;
@@ -7,4 +9,23 @@ export type Currency = {
     };
     flags?: string[];
     precision?: number;
+};
+
+// Describes the shape of the currencies data
+export interface currenciesDataState {
+    currencies: Currency[];
+    filteredCurrencies: Currency[];
+    baseCurrency: string;
+    status: apiStatus;
+}
+
+//Provide initial state
+export const currenciesDataInitialState: currenciesDataState = {
+    currencies: [],
+    filteredCurrencies: [],
+    baseCurrency: '',
+    status: {
+        state: apiState.PRISTINE,
+        error: null
+    }
 };


### PR DESCRIPTION
Currencies slice was very fat right and had some untestable units.
This PR reduces the coupling by moving out functionality and using it by importing.
Also, application types are moved out from the slice since they declare the business data shape, not specifically the slice reducers.